### PR TITLE
Verifier sends results to vault instead of client

### DIFF
--- a/starknet-contracts/pitchlake-verifier/Scarb.toml
+++ b/starknet-contracts/pitchlake-verifier/Scarb.toml
@@ -15,6 +15,7 @@ fp = "0.1.4"
 [dev-dependencies]
 snforge_std = "0.48.1"
 assert_macros = "2.12.0"
+cairo_test = "2.12.0"
 
 [[target.starknet-contract]]
 casm = true

--- a/starknet-contracts/pitchlake-verifier/src/pitchlake_verifier.cairo
+++ b/starknet-contracts/pitchlake-verifier/src/pitchlake_verifier.cairo
@@ -83,7 +83,9 @@ pub mod PitchLakeVerifier {
             .write(IRisc0Groth16VerifierBN254Dispatcher { contract_address: verifier_address });
         self
             .pitchlake_client
-            .write(IFossilClientDispatcher { contract_address: pitchlake_client_address });
+            .write(
+                IFossilClientDispatcher { contract_address: pitchlake_client_address },
+            ); // @dev can omit this
         self.ownable.initializer(owner);
     }
 
@@ -119,9 +121,11 @@ pub mod PitchLakeVerifier {
             journal.twap_result.serialize(ref job_result_data);
             journal.max_return.serialize(ref job_result_data);
 
-            let pitchlake_client: IFossilClientDispatcher = IFossilClientDispatcher{contract_address: pitchlake_job_request.vault_address};
+            let pitchlake_vault: IFossilClientDispatcher = IFossilClientDispatcher {
+                contract_address: pitchlake_job_request.vault_address,
+            };
 
-            pitchlake_client.fossil_callback(job_request_data.span(), job_result_data.span());
+            pitchlake_vault.fossil_callback(job_request_data.span(), job_result_data.span());
 
             self
                 .emit(

--- a/starknet-contracts/pitchlake-verifier/src/pitchlake_verifier.cairo
+++ b/starknet-contracts/pitchlake-verifier/src/pitchlake_verifier.cairo
@@ -40,7 +40,7 @@ pub mod PitchLakeVerifier {
     #[storage]
     struct Storage {
         bn254_verifier: IRisc0Groth16VerifierBN254Dispatcher,
-        pitchlake_client: IFossilClientDispatcher,
+        pitchlake_client: IFossilClientDispatcher, // @dev can omit this
         #[substorage(v0)]
         ownable: OwnableComponent::Storage,
         #[substorage(v0)]
@@ -75,7 +75,7 @@ pub mod PitchLakeVerifier {
     fn constructor(
         ref self: ContractState,
         verifier_address: starknet::ContractAddress,
-        pitchlake_client_address: starknet::ContractAddress,
+        pitchlake_client_address: starknet::ContractAddress, // @dev can omit this
         owner: starknet::ContractAddress,
     ) {
         self
@@ -103,27 +103,25 @@ pub mod PitchLakeVerifier {
 
             let journal = decode_journal(journal);
 
-            let mut proof_data: Array<felt252> = array![];
-
-            // TODO: review the Journal fields that need to be sent to pitchlake client
-            journal.start_timestamp.serialize(ref proof_data);
-            journal.end_timestamp.serialize(ref proof_data);
-            journal.reserve_price.serialize(ref proof_data);
-            journal.floating_point_tolerance.serialize(ref proof_data);
-            journal.reserve_price_tolerance.serialize(ref proof_data);
-            journal.twap_tolerance.serialize(ref proof_data);
-            journal.gradient_tolerance.serialize(ref proof_data);
-            journal.twap_result.serialize(ref proof_data);
-            journal.max_return.serialize(ref proof_data);
-
             let mut job_request_data: Array<felt252> = array![];
             pitchlake_job_request.vault_address.serialize(ref job_request_data);
             pitchlake_job_request.timestamp.serialize(ref job_request_data);
             pitchlake_job_request.program_id.serialize(ref job_request_data);
 
-            let pitchlake_client = self.pitchlake_client.read();
+            let mut job_result_data: Array<felt252> = array![];
+            journal.start_timestamp.serialize(ref job_result_data);
+            journal.end_timestamp.serialize(ref job_result_data);
+            journal.reserve_price.serialize(ref job_result_data);
+            journal.floating_point_tolerance.serialize(ref job_result_data);
+            journal.reserve_price_tolerance.serialize(ref job_result_data);
+            journal.twap_tolerance.serialize(ref job_result_data);
+            journal.gradient_tolerance.serialize(ref job_result_data);
+            journal.twap_result.serialize(ref job_result_data);
+            journal.max_return.serialize(ref job_result_data);
 
-            pitchlake_client.fossil_callback(proof_data.span(), job_request_data.span());
+            let pitchlake_client: IFossilClientDispatcher = IFossilClientDispatcher{contract_address: pitchlake_job_request.vault_address};
+
+            pitchlake_client.fossil_callback(job_request_data.span(), job_result_data.span());
 
             self
                 .emit(

--- a/starknet-contracts/pitchlake-verifier/src/pitchlake_verifier.cairo
+++ b/starknet-contracts/pitchlake-verifier/src/pitchlake_verifier.cairo
@@ -40,7 +40,6 @@ pub mod PitchLakeVerifier {
     #[storage]
     struct Storage {
         bn254_verifier: IRisc0Groth16VerifierBN254Dispatcher,
-        pitchlake_client: IFossilClientDispatcher, // @dev can omit this
         #[substorage(v0)]
         ownable: OwnableComponent::Storage,
         #[substorage(v0)]
@@ -81,11 +80,6 @@ pub mod PitchLakeVerifier {
         self
             .bn254_verifier
             .write(IRisc0Groth16VerifierBN254Dispatcher { contract_address: verifier_address });
-        self
-            .pitchlake_client
-            .write(
-                IFossilClientDispatcher { contract_address: pitchlake_client_address },
-            ); // @dev can omit this
         self.ownable.initializer(owner);
     }
 
@@ -160,7 +154,7 @@ pub mod PitchLakeVerifier {
         }
 
         fn get_pitchlake_client_address(self: @ContractState) -> starknet::ContractAddress {
-            self.pitchlake_client.read().contract_address
+            0xdead.try_into().unwrap()
         }
 
         fn upgrade(ref self: ContractState, new_class_hash: starknet::ClassHash) {


### PR DESCRIPTION
 # Problem: 

PitchlakeVerifier and PitchlakeClient contracts need to know each other's addresses

# Criteria:

- Avoid the need for an initialization function to set one of the contracts' addresses after deployment
- Avoid altering the job request/result/flow and use minimal changes to Fossil (and Pitchlake)

# Proposed Solution:

The `PitchlakeVerifier::verify-proof` function already knows the Vault's address (because it forwards it and other data to the PitchlakeClient, which then forwards to the Vault). So, instead of using a hardcoded middleman contract (PitchlakeClient), we can just add the `PitchlakeClient::fossil_callback` function to the Vault contract. 

# Further Changes:

- Once clarity is added on the Journal field types, we may be able to remove some of the journal arguments passed to the client (Vault) 

- This PR (currently) has the minimal changes necessary to fix the issue. If ok, there are notes left for line of the contract that can be omitted. This entails removing a constructor argument from the PitchlakeVerifier deployment, which might cascade into more necessary changes. Leaving as is is slightly inefficient, but creates the least overhead for Fossil.

- If accepted, PL's next steps are to deploy an instance of this to Sepolia to integrate into our services (and new Vault contracts)

